### PR TITLE
Limit submissions query to 50 results for performance

### DIFF
--- a/backend/db/query.sql.go
+++ b/backend/db/query.sql.go
@@ -709,6 +709,7 @@ const getSubmissionsByGameIDAndUserID = `-- name: GetSubmissionsByGameIDAndUserI
 SELECT submission_id, game_id, user_id, code, code_size, status, created_at FROM submissions
 WHERE game_id = $1 AND user_id = $2
 ORDER BY created_at DESC
+LIMIT 50
 `
 
 type GetSubmissionsByGameIDAndUserIDParams struct {

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -262,7 +262,8 @@ WHERE testcase_id = $1;
 -- name: GetSubmissionsByGameIDAndUserID :many
 SELECT * FROM submissions
 WHERE game_id = $1 AND user_id = $2
-ORDER BY created_at DESC;
+ORDER BY created_at DESC
+LIMIT 50;
 
 -- name: GetSubmissionsByGameID :many
 SELECT *


### PR DESCRIPTION
## Summary
Added a `LIMIT 50` clause to the `GetSubmissionsByGameIDAndUserID` query to improve performance and prevent excessive data retrieval.

## Changes
- Updated `backend/query.sql` to add `LIMIT 50` to the `GetSubmissionsByGameIDAndUserID` query
- Regenerated `backend/db/query.sql.go` to reflect the SQL query changes

## Details
This change limits the number of submissions returned when querying by game ID and user ID to the 50 most recent entries (ordered by `created_at DESC`). This prevents potential performance issues from loading large result sets and aligns with typical pagination patterns for user submission history.

https://claude.ai/code/session_015rm8yZD4va9hRH429u9N6q